### PR TITLE
fix default margins on low density screens

### DIFF
--- a/easydialog/src/main/java/com/michael/easydialog/EasyDialog.java
+++ b/easydialog/src/main/java/com/michael/easydialog/EasyDialog.java
@@ -83,6 +83,9 @@ public class EasyDialog
      */
     private RelativeLayout rlOutsideBackground;
 
+    private int defaultLeftMargin;
+    private int defaultRightMargin;
+
     public EasyDialog(Context context)
     {
         initDialog(context);
@@ -136,6 +139,8 @@ public class EasyDialog
         animatorSetForDialogDismiss = new AnimatorSet();
         objectAnimatorsForDialogShow = new ArrayList<>();
         objectAnimatorsForDialogDismiss = new ArrayList<>();
+        defaultLeftMargin = context.getResources().getDimensionPixelOffset(R.dimen.easy_dialog_default_left_margin);
+        defaultRightMargin = context.getResources().getDimensionPixelOffset(R.dimen.easy_dialog_default_right_margin);
         ini();
     }
 
@@ -171,7 +176,7 @@ public class EasyDialog
                 .setOutsideColor(Color.TRANSPARENT)
                 .setBackgroundColor(Color.BLUE)
                 .setMatchParent(true)
-                .setMarginLeftAndRight(24, 24);
+                .setMarginLeftAndRight(defaultLeftMargin, defaultRightMargin);
     }
 
     /**

--- a/easydialog/src/main/res/values/dimens.xml
+++ b/easydialog/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="easy_dialog_default_left_margin">12dp</dimen>
+    <dimen name="easy_dialog_default_right_margin">12dp</dimen>
+</resources>


### PR DESCRIPTION
On mdpi screens right margin is too high, one should use dips, not pixels.
![3879bae8-c917-11e6-970f-0be7f9f8e031](https://cloud.githubusercontent.com/assets/7129888/21690284/fb03d5e2-d38c-11e6-8439-765cd1f470e6.png)
